### PR TITLE
Improve development workflow

### DIFF
--- a/.bashrc.d/100-firefox-dev
+++ b/.bashrc.d/100-firefox-dev
@@ -1,1 +1,5 @@
-export PATH="/home/gitpod/.mozbuild/git-cinnabar:$PATH"
+# Use a .mozbuild location where it will be saved by Gitpod
+export MOZBUILD_STATE_PATH="/workspace/.mozbuild"
+
+# Add git-cinnabar to the PATH
+export PATH="$MOZBUILD_STATE_PATH/git-cinnabar:$PATH"

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -11,17 +11,17 @@ tasks:
       # Everything below will be executed every time we open Gitpod (either any
       # existing workspace OR a completely new one).
 
-      # This is needed to avoid an error with `./mach bootstrap` but also it is
-      # useful to store `git-cinnabar`.
-      mkdir -p ~/.mozbuild
-
-      # Checkout `git-cinnabar` (only if needed)
-      [[ -d ~/.mozbuild/git-cinnabar ]] || git clone https://github.com/glandium/git-cinnabar ~/.mozbuild/git-cinnabar
-
       # Configure `bash` for the user, and source the `bash` config so that we can use `git cinnabar` right after.
       cd "$GITPOD_REPO_ROOT"
       cp .bashrc.d/100-firefox-dev ~/.bashrc.d/
       source ~/.bashrc.d/100-firefox-dev
+
+      # This is needed to avoid an error with `./mach bootstrap` but also it is
+      # useful to store `git-cinnabar`.
+      mkdir -p "$MOZBUILD_STATE_PATH"
+
+      # Checkout `git-cinnabar` (only if needed)
+      [[ -d "$MOZBUILD_STATE_PATH/git-cinnabar" ]] || git clone https://github.com/glandium/git-cinnabar "$MOZBUILD_STATE_PATH/git-cinnabar"
 
       # Install the `git-cinnabar` helper.
       git cinnabar download

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -8,7 +8,8 @@ image: willdurand/gitpod-firefox-dev:latest
 tasks:
   - name: bootstrap
     before: |
-      # Everything below will be executed every time we open Gitpod (either any.# existing workspace OR a completely new one).
+      # Everything below will be executed every time we open Gitpod (either any
+      # existing workspace OR a completely new one).
 
       # This is needed to avoid an error with `./mach bootstrap` but also it is
       # useful to store `git-cinnabar`.
@@ -17,9 +18,10 @@ tasks:
       # Checkout `git-cinnabar` (only if needed)
       [[ -d ~/.mozbuild/git-cinnabar ]] || git clone https://github.com/glandium/git-cinnabar ~/.mozbuild/git-cinnabar
 
-      # Source the `bash` config so that we can use `git cinnabar` right after.
+      # Configure `bash` for the user, and source the `bash` config so that we can use `git cinnabar` right after.
       cd "$GITPOD_REPO_ROOT"
-      source .bashrc.d/100-firefox-dev
+      cp .bashrc.d/100-firefox-dev ~/.bashrc.d/
+      source ~/.bashrc.d/100-firefox-dev
 
       # Install the `git-cinnabar` helper.
       git cinnabar download
@@ -27,9 +29,6 @@ tasks:
       # `git-cinnabar` says we should set this configuration flag.
       cd "$GITPOD_REPO_ROOT/mozilla-unified"
       git config fetch.prune true
-
-      # Configure `bash` for the user.
-      cp .bashrc.d/100-firefox-dev ~/.bashrc.d/
 
       # Install `git-revise`
       pip install --user git-revise

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -49,7 +49,6 @@ tasks:
       git pull
 
       # Build Firefox.
-      ./mach clobber
       ./mach build
 
 ports:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -23,12 +23,17 @@ tasks:
 
       # Install the `git-cinnabar` helper.
       git cinnabar download
+      
+      # `git-cinnabar` says we should set this configuration flag.
+      cd "$GITPOD_REPO_ROOT/mozilla-unified"
+      git config fetch.prune true
 
       # Configure `bash` for the user.
       cp .bashrc.d/100-firefox-dev ~/.bashrc.d/
 
       # Install `git-revise`
       pip install --user git-revise
+
     init: |
       # Everything below will be executed when we create a new workspace.
 
@@ -40,9 +45,6 @@ tasks:
       python3 bootstrap.py --vcs=git --no-interactive
     command: |
       cd "$GITPOD_REPO_ROOT/mozilla-unified"
-
-      # `git-cinnabar` says we should set this configuration flag.
-      git config fetch.prune true
 
       # Fetch new commits, if any.
       git pull

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -11,27 +11,10 @@ tasks:
       # Everything below will be executed every time we open Gitpod (either any
       # existing workspace OR a completely new one).
 
-      # Configure `bash` for the user, and source the `bash` config so that we can use `git cinnabar` right after.
+      # Configure `bash` for the user, and source the `bash` config
       cd "$GITPOD_REPO_ROOT"
       cp .bashrc.d/100-firefox-dev ~/.bashrc.d/
       source ~/.bashrc.d/100-firefox-dev
-
-      # This is needed to avoid an error with `./mach bootstrap` but also it is
-      # useful to store `git-cinnabar`.
-      mkdir -p "$MOZBUILD_STATE_PATH"
-
-      # Checkout `git-cinnabar` (only if needed)
-      [[ -d "$MOZBUILD_STATE_PATH/git-cinnabar" ]] || git clone https://github.com/glandium/git-cinnabar "$MOZBUILD_STATE_PATH/git-cinnabar"
-
-      # Install the `git-cinnabar` helper.
-      git cinnabar download
-      
-      # `git-cinnabar` says we should set this configuration flag.
-      cd "$GITPOD_REPO_ROOT/mozilla-unified"
-      git config fetch.prune true
-
-      # Install `git-revise`
-      pip install --user git-revise
 
     init: |
       # Everything below will be executed when we create a new workspace.
@@ -39,17 +22,38 @@ tasks:
       # This is needed to avoid an error with `./mach build`
       sudo apt-get update
 
+      # This is needed to avoid an error with `./mach bootstrap` but also it is
+      # useful to store `git-cinnabar`.
+      mkdir -p "$MOZBUILD_STATE_PATH"
+
+      # Checkout `git-cinnabar`
+      git clone https://github.com/glandium/git-cinnabar "$MOZBUILD_STATE_PATH/git-cinnabar"
+
+      # Install the `git-cinnabar` helper.
+      git cinnabar download
+
+      # Install `git-revise`
+      pip install --user git-revise
+
       # Download and execute Mozilla's bootstrap script.
       curl https://hg.mozilla.org/mozilla-central/raw-file/default/python/mozboot/bin/bootstrap.py -O
       python3 bootstrap.py --vcs=git --no-interactive
-    command: |
+
+      # `git-cinnabar` says we should set this configuration flag.
       cd "$GITPOD_REPO_ROOT/mozilla-unified"
+      git config fetch.prune true
 
       # Fetch new commits, if any.
-      git fetch
+      git pull
 
       # Build Firefox.
       ./mach build
+
+    command: |
+      cd "$GITPOD_REPO_ROOT/mozilla-unified"
+
+      # Run Firefox
+      ./mach run
 
 ports:
   # mochitest

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -46,7 +46,7 @@ tasks:
       cd "$GITPOD_REPO_ROOT/mozilla-unified"
 
       # Fetch new commits, if any.
-      git pull
+      git fetch
 
       # Build Firefox.
       ./mach build


### PR DESCRIPTION
Hi @willdurand! I've read your article, and spent some time fiddling with your Gitpod configuration for building Firefox. Thanks for the initial work on this, it really gave me the motivation to set up a full development environment on Gitpod!

While setting up a workspace, I made some cleanups and improvements to the development workflow.

## The issue I had, and improvements made

The main issue I had is that **Firefox was recompiled from scratch every time the workspace started** – which was really slow. I was working on C++ code, so I couldn't even use build artifacts.

With those changes:

- Firefox is built automatically only when creating the workspace (instead of being rebuilt every time),
- When re-opening the workspace, Firefox is just run from the version already built,
- The build cache is preserved between workspace runs.

## Implementation details

Technically, the change is mainly that the `command:` action of Gitpod is no longer "Building Firefox", but "Launching Firefox" (which makes sense).

And preserving the build cache means storing  the`.mozbuild` directory in a directory under `/workspace` instead (so that it get saved by Gitpod).

Tell me if that looks interesting to you!
