### PR TITLE
Add env vars for configuring tools (try server access, phabricator)

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -27,6 +27,10 @@ tasks:
       }
       [[ ! -z "${FIREFOX_TRY_USERNAME}" ]] && [[ ! -z "${FIREFOX_TRY_SSH_KEY}" ]] && configure_try_credentials
 
+      # Store the MozPhab credentials inside the workspace, so that they are restored when the workspace is re-opened.
+      touch /workspace/.arcrc
+      [[ ! -z "${FIREFOX_PHABRICATOR_API_TOKEN}" ]] && echo "{\"hosts\": {\"https://phabricator.services.mozilla.com/api/\": {\"token\": \"${FIREFOX_PHABRICATOR_API_TOKEN}\"}}}" > ~/.arcrc
+
     init: |
       # Everything below will be executed when we create a new workspace.
 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -15,6 +15,17 @@ tasks:
       cd "$GITPOD_REPO_ROOT"
       cp .bashrc.d/100-firefox-dev ~/.bashrc.d/
       source ~/.bashrc.d/100-firefox-dev
+      
+      # Try server: if both FIREFOX_TRY_USERNAME and FIREFOX_TRY_SSH_KEY environment variables are present,
+      # configure the credentials for pushing to try.
+      #
+      # NB: when defining the FIREFOX_TRY_SSH_KEY env var variable in Gitpod web UI, replace newlines by "\n".
+      function configure_try_credentials() {
+        echo -e "Host hg.mozilla.org\n  User ${FIREFOX_TRY_USERNAME}" >> ~/.ssh/config
+        echo -e "$FIREFOX_TRY_SSH_KEY" > ~/.ssh/id_rsa
+        chmod 600 ~/.ssh/id_rsa
+      }
+      [[ ! -z "${FIREFOX_TRY_USERNAME}" ]] && [[ ! -z "${FIREFOX_TRY_SSH_KEY}" ]] && configure_try_credentials
 
     init: |
       # Everything below will be executed when we create a new workspace.

--- a/README.md
+++ b/README.md
@@ -8,3 +8,23 @@ Try now by clicking the button below:
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/willdurand/gitpod-firefox-dev)
 
 [gitpod.io]: https://gitpod.io/
+
+## Configuration
+
+When opening a workspace, the standard Mozilla developer utilities are already available (git-cinnabar,
+mach, moz-phab, etc.) However, by defining some optional environment variables in your Gitpod account,
+you can pre-configure some of this tools.
+
+### Try server credentials
+
+Mozilla's [try server](https://wiki.mozilla.org/ReleaseEngineering/TryServer) allows developers to test
+a patch before checking the patch to the core repository.
+
+If you have [access to the try server](https://wiki.mozilla.org/ReleaseEngineering/TryServer#Getting_access_to_the_Try_Server), you can add your try credentials to Gitpod. This will allow `./mach try` to work right out of the box.
+
+For this, define the following environement variables in your Gitpod account:
+
+- **FIREFOX_TRY_USERNAME**: the username of your try server account.
+- **FIREFOX_TRY_SSH_KEY**: the private ssh key of your try server account. The key must be formatted
+  with '\n' for each newline.
+

--- a/README.md
+++ b/README.md
@@ -28,3 +28,11 @@ For this, define the following environement variables in your Gitpod account:
 - **FIREFOX_TRY_SSH_KEY**: the private ssh key of your try server account. The key must be formatted
   with '\n' for each newline.
 
+### MozPhab credentials
+
+[Phabricator](https://wiki.mozilla.org/Phabricator#Phabricator_at_Mozilla) is used for Firefox's code reviews.
+The `moz-phab` command-line tool comes pre-installed in the workspace, but it needs an API key to work properly.
+
+To configure `moz-phab` with your own credentials, define the following environement variables in your Gitpod account:
+
+- **FIREFOX_PHABRICATOR_API_TOKEN**: your Phabricator API Token, typically retrieved from [https://phabricator.services.mozilla.com/conduit/login/](https://phabricator.services.mozilla.com/conduit/login/).


### PR DESCRIPTION
When two env vars are configured in Gitpod (`TRY_USERNAME` and `TRY_SSH_KEY`), ssh access to the try server will be configured on workspace creation.

This then allow developers to push builds to Try without re-configuring their credentials everytime.