### PR TITLE
gitpod: move before/init scripts to files

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -10,63 +10,14 @@ tasks:
     before: |
       # Everything below will be executed every time we open Gitpod (either any
       # existing workspace OR a completely new one).
-
-      # Configure `bash` for the user, and source the `bash` config
-      cd "$GITPOD_REPO_ROOT"
-      cp .bashrc.d/100-firefox-dev ~/.bashrc.d/
-      source ~/.bashrc.d/100-firefox-dev
-      
-      # Try server: if both FIREFOX_TRY_USERNAME and FIREFOX_TRY_SSH_KEY environment variables are present,
-      # configure the credentials for pushing to try.
-      #
-      # NB: when defining the FIREFOX_TRY_SSH_KEY env var variable in Gitpod web UI, replace newlines by "\n".
-      function configure_try_credentials() {
-        echo -e "Host hg.mozilla.org\n  User ${FIREFOX_TRY_USERNAME}" >> ~/.ssh/config
-        echo -e "$FIREFOX_TRY_SSH_KEY" > ~/.ssh/id_rsa
-        chmod 600 ~/.ssh/id_rsa
-      }
-      [[ ! -z "${FIREFOX_TRY_USERNAME}" ]] && [[ ! -z "${FIREFOX_TRY_SSH_KEY}" ]] && configure_try_credentials
-
-      # Store the MozPhab credentials inside the workspace, so that they are restored when the workspace is re-opened.
-      touch /workspace/.arcrc
-      [[ ! -z "${FIREFOX_PHABRICATOR_API_TOKEN}" ]] && echo "{\"hosts\": {\"https://phabricator.services.mozilla.com/api/\": {\"token\": \"${FIREFOX_PHABRICATOR_API_TOKEN}\"}}}" > ~/.arcrc
+      "$GITPOD_REPO_ROOT/.gitpod/scripts/bootstrap-before.sh"
 
     init: |
       # Everything below will be executed when we create a new workspace.
-
-      # This is needed to avoid an error with `./mach build`
-      sudo apt-get update
-
-      # This is needed to avoid an error with `./mach bootstrap` but also it is
-      # useful to store `git-cinnabar`.
-      mkdir -p "$MOZBUILD_STATE_PATH"
-
-      # Checkout `git-cinnabar`
-      git clone https://github.com/glandium/git-cinnabar "$MOZBUILD_STATE_PATH/git-cinnabar"
-
-      # Install the `git-cinnabar` helper.
-      git cinnabar download
-
-      # Install `git-revise`
-      pip install --user git-revise
-
-      # Download and execute Mozilla's bootstrap script.
-      curl https://hg.mozilla.org/mozilla-central/raw-file/default/python/mozboot/bin/bootstrap.py -O
-      python3 bootstrap.py --vcs=git --no-interactive
-
-      # `git-cinnabar` says we should set this configuration flag.
-      cd "$GITPOD_REPO_ROOT/mozilla-unified"
-      git config fetch.prune true
-
-      # Fetch new commits, if any.
-      git pull
-
-      # Build Firefox.
-      ./mach build
+      "$GITPOD_REPO_ROOT/.gitpod/scripts/bootstrap-init.sh"
 
     command: |
       cd "$GITPOD_REPO_ROOT/mozilla-unified"
-
       # Run Firefox
       ./mach run
 

--- a/.gitpod/scripts/bootstrap-before.sh
+++ b/.gitpod/scripts/bootstrap-before.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -xeuo pipefail
+
+# Configure `bash` for the user, and source the `bash` config.
+cd "$GITPOD_REPO_ROOT" || exit 2
+cp .bashrc.d/100-firefox-dev ~/.bashrc.d/
+source ~/.bashrc.d/100-firefox-dev
+
+# Try server: if both FIREFOX_TRY_USERNAME and FIREFOX_TRY_SSH_KEY environment
+# variables are present, configure the credentials for pushing to try.
+#
+# NB: when defining the FIREFOX_TRY_SSH_KEY env var variable in Gitpod web UI,
+# replace newlines by "\n".
+function configure_try_credentials() {
+	echo -e "Host hg.mozilla.org\n  User $FIREFOX_TRY_USERNAME" >> ~/.ssh/config
+	echo -e "$FIREFOX_TRY_SSH_KEY" > ~/.ssh/id_rsa
+	chmod 600 ~/.ssh/id_rsa
+}
+[[ -n "${FIREFOX_TRY_USERNAME-}" ]] && [[ -n "${FIREFOX_TRY_SSH_KEY-}" ]] && configure_try_credentials
+
+# Store the MozPhab credentials inside the workspace, so that they are restored
+# when the workspace is re-opened.
+touch /workspace/.arcrc
+[[ -n "${FIREFOX_PHABRICATOR_API_TOKEN-}" ]] && echo "{\"hosts\": {\"https://phabricator.services.mozilla.com/api/\": {\"token\": \"${FIREFOX_PHABRICATOR_API_TOKEN}\"}}}" > ~/.arcrc
+
+# Force the exit code here because the previous command could return a non-zero
+# exit code when there is no Phabricator token...
+exit 0

--- a/.gitpod/scripts/bootstrap-init.sh
+++ b/.gitpod/scripts/bootstrap-init.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -xeuo pipefail
+
+# This is needed to avoid an error with `./mach build`.
+sudo apt-get update
+
+# This is needed to avoid an error with `./mach bootstrap` but also it is
+# useful to store `git-cinnabar`.
+mkdir -p "$MOZBUILD_STATE_PATH"
+
+# Checkout `git-cinnabar`.
+git clone https://github.com/glandium/git-cinnabar "$MOZBUILD_STATE_PATH/git-cinnabar"
+
+# Install the `git-cinnabar` helper.
+git cinnabar download
+
+# Install `git-revise`
+pip install --user git-revise
+
+# Download and execute Mozilla's bootstrap script.
+curl https://hg.mozilla.org/mozilla-central/raw-file/default/python/mozboot/bin/bootstrap.py -O
+python3 bootstrap.py --vcs=git --no-interactive
+
+# `git-cinnabar` says we should set this configuration flag.
+cd "$GITPOD_REPO_ROOT/mozilla-unified" || exit 2
+git config fetch.prune true
+
+# Fetch new commits, if any.
+git pull
+
+# Build Firefox.
+./mach build


### PR DESCRIPTION
Fixes https://github.com/willdurand/gitpod-firefox-dev/issues/3, although the actual fix for this issue is "just" the exit 0 line. Moving the scripts to separate files will make the gitpod config file a bit more readable, though.

(like #4 but with the right patch this time)